### PR TITLE
Support user selectable list of ciphers

### DIFF
--- a/choria.go
+++ b/choria.go
@@ -87,10 +87,14 @@ type ChoriaPluginConfig struct {
 	RemoteSignerURL              string   `confkey:"plugin.choria.security.request_signer.url"`
 
 	// file security
-	FileSecurityCertificate string `confkey:"plugin.security.file.certificate" type:"path_string"`
-	FileSecurityKey         string `confkey:"plugin.security.file.key" type:"path_string"`
-	FileSecurityCA          string `confkey:"plugin.security.file.ca" type:"path_string"`
-	FileSecurityCache       string `confkey:"plugin.security.file.cache" type:"path_string"`
+	FileSecurityCertificate string   `confkey:"plugin.security.file.certificate" type:"path_string"`
+	FileSecurityKey         string   `confkey:"plugin.security.file.key" type:"path_string"`
+	FileSecurityCA          string   `confkey:"plugin.security.file.ca" type:"path_string"`
+	FileSecurityCache       string   `confkey:"plugin.security.file.cache" type:"path_string"`
+
+	// TLS Parameters
+	CipherSuites            []string `confkey:"plugin.security.cipher_suites" type:"comma_split"`
+	ECCCurves               []string `confkey:"plugin.security.ecc_curves", type:"comma_split"`
 
 	// pkcs11 security
 	PKCS11DriverFile string `confkey:"plugin.security.pkcs11.driver_file" type:"path_string"`

--- a/config.go
+++ b/config.go
@@ -47,7 +47,6 @@ type Config struct {
 	RPCLimitMethod            string   `confkey:"rpclimitmethod" default:"first" validate:"enum=first,random"`
 	LoggerType                string   `confkey:"logger_type" default:"file"`
 	FactCacheTime             int      `confkey:"fact_cache_time" default:"300"`
-	SSLCipher                 string   `confkey:"ssl_cipher" default:"aes-256-cbc"`
 	Threaded                  bool     `confkey:"threaded" default:"false"`
 	TTL                       int      `confkey:"ttl" default:"60"`
 	DefaultDiscoveryOptions   []string `confkey:"default_discovery_options"`


### PR DESCRIPTION
Support for https://github.com/choria-io/go-security/issues/65

Rename SSLCipher (not being used anywhere) to something that doesn't reference a dead protocol.

Add support for ECC curve preferences.